### PR TITLE
Reverser: fix buffer wraparound

### DIFF
--- a/plugins/Reverser/BitrotReverser.cpp
+++ b/plugins/Reverser/BitrotReverser.cpp
@@ -174,7 +174,7 @@ protected:
                 }
 
                 int advance = toggledValue(params.switchDir) ? 1 : -1;
-                readPos = (readPos + advance) % lbuffer.size();
+                readPos = (readPos + advance + lbuffer.size()) % lbuffer.size();
                 outputs[0][i] = lbuffer[readPos];
                 outputs[1][i] = rbuffer[readPos];
             } else {


### PR DESCRIPTION
The C % operator does not do what you would expect for negative inputs. Adding the buffer size ensures we do not end up in the wrong place when reversing and hitting the start of the buffer.